### PR TITLE
Minor bugfixes i encountered while trying to run the SBI detector

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.1-runtime-ubuntu20.04
+FROM nvidia/cuda:11.4.3-runtime-ubuntu20.04
 
 
 RUN apt-get -y update && \

--- a/src/inference/inference_image.py
+++ b/src/inference/inference_image.py
@@ -1,4 +1,5 @@
 import os
+import cv2
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -7,7 +8,6 @@ import torchvision
 from torchvision import datasets,transforms,models,utils
 import numpy as np
 import matplotlib.pyplot as plt
-import os
 import pandas as pd
 from PIL import Image
 import sys


### PR DESCRIPTION
As specified in the commits the relevant changes are:

- **src/inference/inference_image.py** - Remove the double _**os**_ library import, add the _**cv2**_ library that is missing
- **dockerfiles/Dockerfile** - Modify image ver since the current one doesn't exist (**_11.4.1 :arrow_forward: 11.4.3_**)

If there are any questions feel free to ask/discuss :smile: 